### PR TITLE
Fix dataclass order and update dependencies

### DIFF
--- a/api/analyzer.py
+++ b/api/analyzer.py
@@ -12,14 +12,14 @@ logger = logging.getLogger(__name__)
 @dataclass
 class Entity:
     id: str
-    text: str  
+    text: str
     type: str
     start: int
     end: int
     confidence: float
     replacement: str
-    selected: bool = True
     source: str  # 'regex' ou 'ner'
+    selected: bool = True
     occurrences: int = 1
 
 class HybridAnalyzer:
@@ -452,7 +452,7 @@ class HybridAnalyzer:
                 return False
             
             # Vérifier que ça ressemble à un nom (lettres + espaces/tirets seulement)
-            if not re.match(r'^[A-Za-zÀ-ÿ\s\'-]+, text_clean):
+            if not re.match(r"^[A-Za-zÀ-ÿ\s'\-]+$", text_clean):
                 return False
             
             return True

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,10 +1,9 @@
-
 fastapi==0.104.1
 uvicorn[standard]==0.24.0
 python-multipart==0.0.6
 transformers==4.35.0
-torch==2.1.0
-tokenizers==0.15.0
+torch==2.2.0
+tokenizers==0.14.1
 python-docx==1.1.0
 PyPDF2==3.0.1
 pdf2image==1.16.3

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import UploadPage from './pages/UploadPage';
 import EntityControlPage from './pages/EntityControlPage';

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { AnalyzeResponse, CustomEntity, Entity } from '../types/entities';
+import { AnalyzeResponse, Entity } from '../types/entities';
 
 const API_BASE_URL = '/api';
 

--- a/src/stores/anonymizerStore.ts
+++ b/src/stores/anonymizerStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { Entity, EntityStats, CustomEntity } from '../types/entities';
+import { Entity, EntityStats } from '../types/entities';
 
 interface AnonymizerState {
   sessionId: string | null;


### PR DESCRIPTION
## Summary
- reorder `Entity` dataclass fields
- fix regex string in analyzer
- update backend requirements for Python 3.12
- remove unused React and TypeScript imports

## Testing
- `pip install -r api/requirements.txt`
- `python -c "from api.analyzer import hybrid_analyzer; print('Code Python OK')"`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889dfe37d58832da328c80669d9f388