### PR TITLE
Fix invalid regex ranges

### DIFF
--- a/api/analyzer.py
+++ b/api/analyzer.py
@@ -84,7 +84,7 @@ class HybridAnalyzer:
                 # SIREN : 9 chiffres (avec validation checksum)
                 r'\b(?:SIREN\s*:?\s*)?(\d{3}[\s\.]?\d{3}[\s\.]?\d{3})\b',
                 # RCS avec numéro d'identification
-                r'RCS\s+[A-Z][a-zA-Z-\s]+\s+(\d{3}[\s\.]?\d{3}[\s\.]?\d{3}(?:[\s\.]?\d{5})?)',
+                r'RCS\s+[A-Z][a-zA-Z\s-]+\s+(\d{3}[\s\.]?\d{3}[\s\.]?\d{3}(?:[\s\.]?\d{5})?)',
                 # Numéro TVA intracommunautaire français
                 r'(?:n°\s*TVA\s*:?\s*|TVA\s+intra\w*\s*:?\s*)?FR\s*(\d{2}\s?\d{9})',
                 # Code APE/NAF
@@ -98,11 +98,11 @@ class HybridAnalyzer:
             ],
             'ADRESSE': [
                 # Adresses françaises complètes avec numéro + type voie + nom + ville
-                r'\d+(?:\s+(?:bis|ter|quater))?\s+(?:rue|avenue|boulevard|place|impasse|allée|square|passage|chemin|route|cours|quai)\s+[^,\n.]{5,}(?:\s+\d{5}\s+[A-ZÀÁÂÄÇÉÈÊËÏÎÔÖÙÚÛÜÑ][a-zàáâäçéèêëïîôöùúûüñ-\s]+)?',
+                r'\d+(?:\s+(?:bis|ter|quater))?\s+(?:rue|avenue|boulevard|place|impasse|allée|square|passage|chemin|route|cours|quai)\s+[^,\n.]{5,}(?:\s+\d{5}\s+[A-ZÀÁÂÄÇÉÈÊËÏÎÔÖÙÚÛÜÑ][a-zàáâäçéèêëïîôöùúûüñ\s-]+)?',
                 # Code postal + ville (format français)
                 r'\b\d{5}\s+[A-ZÀÁÂÄÇÉÈÊËÏÎÔÖÙÚÛÜÑ][A-ZÀÁÂÄÇÉÈÊËÏÎÔÖÙÚÛÜÑ\s-]{2,}\b',
                 # Format avec virgules (adresse sur plusieurs lignes)
-                r'\d+(?:\s+(?:bis|ter|quater))?\s+(?:rue|avenue|boulevard|place|impasse|allée|square|passage|chemin|route)\s+[^,\n]{5,},\s*\d{5}\s+[A-ZÀÁÂÄÇÉÈÊËÏÎÔÖÙÚÛÜÑ][a-zàáâäçéèêëïîôöùúûüñ-\s]+'
+                r'\d+(?:\s+(?:bis|ter|quater))?\s+(?:rue|avenue|boulevard|place|impasse|allée|square|passage|chemin|route)\s+[^,\n]{5,},\s*\d{5}\s+[A-ZÀÁÂÄÇÉÈÊËÏÎÔÖÙÚÛÜÑ][a-zàáâäçéèêëïîôöùúûüñ\s-]+'
             ],
             'REFERENCE_JURIDIQUE': [
                 # Références spécifiques au domaine juridique français

--- a/api/models.py
+++ b/api/models.py
@@ -121,7 +121,7 @@ STRUCTURED_ENTITY_TYPES = {
         'patterns': [
             r'\b(?:SIRET\s*:?\s*)?(\d{3}[\s\.]?\d{3}[\s\.]?\d{3}[\s\.]?\d{5})\b',
             r'\b(?:SIREN\s*:?\s*)?(\d{3}[\s\.]?\d{3}[\s\.]?\d{3})\b',
-            r'RCS\s+[A-Z][a-zA-Z-\s]+\s+(\d{3}[\s\.]?\d{3}[\s\.]?\d{3}(?:[\s\.]?\d{5})?)',
+            r'RCS\s+[A-Z][a-zA-Z\s-]+\s+(\d{3}[\s\.]?\d{3}[\s\.]?\d{3}(?:[\s\.]?\d{5})?)',
             r'(?:n°\s*TVA\s*:?\s*|TVA\s+intra\w*\s*:?\s*)?FR\s*(\d{2}\s?\d{9})',
             r'(?:APE|NAF)\s*:?\s*(\d{4}[A-Z])'
         ],
@@ -139,7 +139,7 @@ STRUCTURED_ENTITY_TYPES = {
     },
     'ADRESSE': {
         'patterns': [
-            r'\d+(?:\s+(?:bis|ter|quater))?\s+(?:rue|avenue|boulevard|place|impasse|allée|square|passage|chemin|route|cours|quai)\s+[^,\n.]{5,}(?:\s+\d{5}\s+[A-ZÀÁÂÄÇÉÈÊËÏÎÔÖÙÚÛÜÑ][a-zàáâäçéèêëïîôöùúûüñ-\s]+)?',
+            r'\d+(?:\s+(?:bis|ter|quater))?\s+(?:rue|avenue|boulevard|place|impasse|allée|square|passage|chemin|route|cours|quai)\s+[^,\n.]{5,}(?:\s+\d{5}\s+[A-ZÀÁÂÄÇÉÈÊËÏÎÔÖÙÚÛÜÑ][a-zàáâäçéèêëïîôöùúûüñ\s-]+)?',
             r'\b\d{5}\s+[A-ZÀÁÂÄÇÉÈÊËÏÎÔÖÙÚÛÜÑ][A-ZÀÁÂÄÇÉÈÊËÏÎÔÖÙÚÛÜÑ\s-]{2,}\b'
         ],
         'default_replacement': 'ADRESSE_MASQUEE',


### PR DESCRIPTION
## Summary
- correct hyphen placement inside several character classes
- keep postal address regex working

## Testing
- `python - <<'PY'
import re
from api.models import STRUCTURED_ENTITY_TYPES
for ent, data in STRUCTURED_ENTITY_TYPES.items():
    for pattern in data['patterns']:
        re.compile(pattern)
print('ok models')
PY`
- `python - <<'PY'
import re
from api.analyzer import HybridAnalyzer
ha = HybridAnalyzer()
for patterns in ha.structured_patterns.values():
    for pat in patterns:
        assert isinstance(pat, re.Pattern)
print('ok analyzer', sum(len(p) for p in ha.structured_patterns.values()))
PY`


------
https://chatgpt.com/codex/tasks/task_e_688a277d3144832dab27f699ed94564f