### PR TITLE
Fix SIRET/SIREN validation

### DIFF
--- a/api/analyzer.py
+++ b/api/analyzer.py
@@ -365,43 +365,29 @@ class HybridAnalyzer:
         # Par défaut : validation basique
         return len(text.strip()) >= 3, 0.80
     
-    def _validate_siret_checksum(self, siret: str) -> bool:
-        """Validation checksum SIRET avec algorithme de Luhn"""
+    def _luhn_checksum(self, number: str) -> bool:
+        """Algorithme de Luhn générique utilisé pour SIRET/SIREN"""
         try:
-            if len(siret) != 14:
-                return False
-            
-            # Algorithme de Luhn modifié pour SIRET
             total = 0
-            for i, digit in enumerate(siret):
-                weight = 2 if i % 2 == 1 else 1
-                product = int(digit) * weight
-                if product > 9:
-                    product = (product // 10) + (product % 10)
-                total += product
-            
+            reverse_digits = number[::-1]
+            for i, digit in enumerate(reverse_digits):
+                n = int(digit)
+                if i % 2 == 1:
+                    n *= 2
+                    if n > 9:
+                        n -= 9
+                total += n
             return total % 10 == 0
-        except:
+        except Exception:
             return False
-    
+
+    def _validate_siret_checksum(self, siret: str) -> bool:
+        """Validation checksum SIRET"""
+        return len(siret) == 14 and self._luhn_checksum(siret)
+
     def _validate_siren_checksum(self, siren: str) -> bool:
         """Validation checksum SIREN"""
-        try:
-            if len(siren) != 9:
-                return False
-            
-            # Algorithme de validation SIREN
-            total = 0
-            for i, digit in enumerate(siren):
-                weight = 2 if i % 2 == 1 else 1
-                product = int(digit) * weight
-                if product > 9:
-                    product = (product // 10) + (product % 10)
-                total += product
-            
-            return total % 10 == 0
-        except:
-            return False
+        return len(siren) == 9 and self._luhn_checksum(siren)
     
     def _map_ner_label(self, label: str) -> Optional[str]:
         """

--- a/api/tests/test_siret_siren.py
+++ b/api/tests/test_siret_siren.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from api.analyzer import HybridAnalyzer
+
+
+@pytest.fixture
+def analyzer():
+    return HybridAnalyzer()
+
+
+def test_valid_siret(analyzer):
+    assert analyzer._validate_siret_checksum("73282932000074")
+
+
+def test_invalid_siret(analyzer):
+    assert not analyzer._validate_siret_checksum("73282932000075")
+
+
+def test_valid_siren(analyzer):
+    assert analyzer._validate_siren_checksum("732829320")
+
+
+def test_invalid_siren(analyzer):
+    assert not analyzer._validate_siren_checksum("732829321")


### PR DESCRIPTION
## Summary
- implement proper Luhn checksum helper and use it for SIRET/SIREN
- add unit tests for SIRET/SIREN validation

## Testing
- `pytest -q`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688b15c63050832dbbb8f28c5aaf32c5