### PR TITLE
Fix SPA routing, store persistence, API sync, and backend endpoints

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -37,6 +37,7 @@ class Entity(BaseModel):
     selected: bool = True
     replacement: str = ""
     occurrences: int = 1
+    groupId: Optional[str] = None
     
     def __init__(self, **data):
         if 'id' not in data or not data['id']:
@@ -50,6 +51,13 @@ class CustomEntity(BaseModel):
     text: str
     entity_type: EntityTypeEnum
     replacement: str
+
+class EntityGroup(BaseModel):
+    id: str
+    name: str
+    replacement: str
+    entities: List[str]
+    createdAt: str
 
 class EntityStats(BaseModel):
     """
@@ -82,6 +90,11 @@ class AuditLog(BaseModel):
     entities_anonymized: int
     replacement_summary: List[Dict[str, Any]]
     architecture: str = "REGEX_structured + NER_complex"
+
+class SyncSessionPayload(BaseModel):
+    session_id: str
+    entities: List[Entity]
+    groups: List[EntityGroup] = []
 
 # Configuration des types d'entités avec séparation REGEX/NER
 STRUCTURED_ENTITY_TYPES = {

--- a/src/components/AddEntityModal.tsx
+++ b/src/components/AddEntityModal.tsx
@@ -9,8 +9,8 @@ interface AddEntityModalProps {
 }
 
 const AddEntityModal: React.FC<AddEntityModalProps> = ({ isOpen, onClose }) => {
-  const { 
-    textPreview, 
+  const {
+    textPreview,
     addCustomEntity,
     entities
   } = useAnonymizerStore();
@@ -20,6 +20,8 @@ const AddEntityModal: React.FC<AddEntityModalProps> = ({ isOpen, onClose }) => {
   const [replacement, setReplacement] = useState('');
   const [showPreview, setShowPreview] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitError, setSubmitError] = useState<string>('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   React.useEffect(() => {
     if (isOpen) {
@@ -73,13 +75,19 @@ const AddEntityModal: React.FC<AddEntityModalProps> = ({ isOpen, onClose }) => {
   const handleSubmit = () => {
     if (!validateForm()) return;
     
+    setSubmitError('');
+    setIsSubmitting(true);
     addCustomEntity(
       entityText.trim(),
       entityType,
       replacement.trim()
-    );
-    
-    onClose();
+    ).then(() => {
+      onClose();
+    }).catch((e: any) => {
+      setSubmitError(e.message);
+    }).finally(() => {
+      setIsSubmitting(false);
+    });
   };
 
   const previewText = React.useMemo(() => {
@@ -311,12 +319,24 @@ const AddEntityModal: React.FC<AddEntityModalProps> = ({ isOpen, onClose }) => {
             >
               Annuler
             </button>
+            {submitError && (
+              <div className="text-red-600 text-sm flex items-center gap-1 mr-auto">
+                <AlertCircle size={14} /> {submitError}
+              </div>
+            )}
             <button
               onClick={handleSubmit}
-              disabled={!entityText.trim() || !replacement.trim()}
+              disabled={isSubmitting || !entityText.trim() || !replacement.trim()}
               className="px-6 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
             >
-              <Plus size={16} />
+              {isSubmitting ? (
+                <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4l3-3-3-3v4a8 8 0 00-8 8h4z"></path>
+                </svg>
+              ) : (
+                <Plus size={16} />
+              )}
               Ajouter l'entité
             </button>
           </div>

--- a/src/pages/EntityControlPage.tsx
+++ b/src/pages/EntityControlPage.tsx
@@ -6,7 +6,7 @@ import {
   Search, X
 } from 'lucide-react';
 import { useAnonymizerStore } from '../stores/anonymizerStore';
-import { generateAnonymizedDocument } from '../services/api';
+import { generateAnonymizedDocument, syncSession } from '../services/api';
 import { Entity, ENTITY_TYPE_COLORS, ENTITY_TYPE_ICONS } from '../types/entities';
 
 // Import des nouveaux composants
@@ -86,24 +86,24 @@ const EntityControlPage: React.FC = () => {
       setError(null);
       
       const selectedEntities = getSelectedEntities();
-      
+
       if (selectedEntities.length === 0) {
         setError('Aucune entité sélectionnée pour l\'anonymisation');
         return;
       }
 
-      // 🧠 APPLIQUER L'ALGORITHME DE GROUPEMENT INTELLIGENT
+      await syncSession(sessionId, entities, entityGroups);
+
       const replacements: Record<string, string> = {};
       selectedEntities.forEach(entity => {
         replacements[entity.text] = entity.replacement;
       });
 
-      // Démonstration de l'algorithme corrigé
       console.log('🔄 Application de l\'algorithme de groupement intelligent...');
       const testText = selectedEntities.slice(0, 3).map(e => e.text).join(' et ');
       console.log('Texte test:', testText);
       console.log('Résultat avec tri par longueur:', applyGroupReplacements(testText, replacements));
-      
+
       const blob = await generateAnonymizedDocument(sessionId, selectedEntities);
       
       const url = window.URL.createObjectURL(blob);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,11 +1,14 @@
+/// <reference types="vite/client" />
 import axios from 'axios';
-import { AnalyzeResponse, Entity, CustomEntity } from '../types/entities';
+import { AnalyzeResponse, Entity, CustomEntity, EntityGroup } from '../types/entities';
 
-const API_BASE_URL = '/api';
+const API_BASE_URL = import.meta.env.DEV
+  ? (import.meta.env.VITE_API_URL || 'http://localhost:8000/api')
+  : '/api';
 
 const api = axios.create({
   baseURL: API_BASE_URL,
-  timeout: 300000, // 5 minutes pour les gros fichiers
+  timeout: 30000,
 });
 
 api.interceptors.response.use(
@@ -114,6 +117,20 @@ export const removeEntityGroup = async (
   formData.append('group_id', groupId);
 
   const response = await api.delete('/remove-group', { data: formData });
+  return response.data;
+};
+
+export const syncSession = async (
+  sessionId: string,
+  entities: Entity[],
+  groups: EntityGroup[]
+): Promise<{ success: boolean }> => {
+  const payload = {
+    session_id: sessionId,
+    entities,
+    groups
+  };
+  const response = await api.post('/sync-session', payload);
   return response.data;
 };
 

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,13 @@
     {
       "src": "/api/(.*)",
       "dest": "/api/main.py"
+    },
+    {
+      "handle": "filesystem"
+    },
+    {
+      "src": "/(.*)",
+      "dest": "/index.html"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add SPA fallback routes for Vercel
- Persist anonymizer state with zustand and wire actions to backend APIs
- Implement missing FastAPI endpoints for entity editing, grouping and session sync

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688b181d2920832d833c17ec2152e511