### PR TITLE
Implement advanced NER-based anonymization mode

### DIFF
--- a/api/advanced_analyzer.py
+++ b/api/advanced_analyzer.py
@@ -1,0 +1,29 @@
+from typing import Dict
+from transformers import pipeline
+from .analyzer import hybrid_analyzer
+
+_NER_PIPELINE = None
+
+def analyze_advanced(text: str) -> Dict:
+    entities = []
+    for e in hybrid_analyzer._extract_structured_entities(text):
+        entities.append({"text": e.text, "label": e.type, "start": e.start, "end": e.end, "source": "REGEX"})
+    global _NER_PIPELINE
+    if _NER_PIPELINE is None:
+        _NER_PIPELINE = pipeline(
+            "ner",
+            model="cmarkea/distilcamembert-base-ner",
+            tokenizer="cmarkea/distilcamembert-base-ner",
+            aggregation_strategy="simple",
+        )
+    ner_results = _NER_PIPELINE(text)
+    existing = {(d["start"], d["end"], d["text"].lower(), d["label"]) for d in entities}
+    for r in ner_results:
+        if r["entity_group"] not in {"PER", "ORG"}:
+            continue
+        key = (r["start"], r["end"], r["word"].lower(), r["entity_group"])
+        if key in existing:
+            continue
+        entities.append({"text": r["word"], "label": r["entity_group"], "start": r["start"], "end": r["end"], "source": "NER"})
+        existing.add(key)
+    return {"entities": entities}


### PR DESCRIPTION
## Summary
- add `analyze_advanced` to perform regex and NER-based entity extraction
- lazily load `cmarkea/distilcamembert-base-ner` and deduplicate results

## Testing
- `cd api && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b572b4084832dab502f499f21155c