### PR TITLE
fix: disable TensorFlow integration

### DIFF
--- a/api/advanced_analyzer.py
+++ b/api/advanced_analyzer.py
@@ -1,4 +1,14 @@
+"""Advanced analysis helpers that rely solely on the PyTorch backend."""
+
+import os
+import warnings
 from typing import Dict
+
+# Ensure transformers never attempts to load TensorFlow
+os.environ.setdefault("TRANSFORMERS_NO_TF", "1")
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
+warnings.filterwarnings("ignore", category=UserWarning, module="tensorflow")
+
 from transformers import pipeline
 from .analyzer import hybrid_analyzer
 

--- a/api/analyzer.py
+++ b/api/analyzer.py
@@ -1,11 +1,28 @@
+"""Core anonymization logic leveraging HuggingFace transformers.
+
+This module is configured to run in a PyTorch-only environment. TensorFlow is
+explicitly disabled to avoid import errors caused by optional TensorFlow
+dependencies inside ``transformers``.  The environment variables are set before
+importing ``transformers`` so that the library never attempts to load
+TensorFlow.
+"""
+
+import os
+import warnings
 import re
-from transformers import AutoTokenizer, AutoModelForTokenClassification, pipeline
 from typing import List, Dict, Optional, Tuple
 from dataclasses import dataclass
 from functools import lru_cache
 import time
 import hashlib
 import logging
+
+# Disable TensorFlow integration in transformers and silence TF warnings
+os.environ.setdefault("TRANSFORMERS_NO_TF", "1")
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
+warnings.filterwarnings("ignore", category=UserWarning, module="tensorflow")
+
+from transformers import AutoTokenizer, AutoModelForTokenClassification, pipeline
 
 logger = logging.getLogger(__name__)
 

--- a/api/fix_dependencies.py
+++ b/api/fix_dependencies.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Utility script to remove TensorFlow and reinstall PyTorch-only deps.
+
+Running this script helps resolve import errors caused by TensorFlow being
+pulled in transitively by transformers.  It removes any TensorFlow packages and
+pins the versions of ``transformers`` and ``torch`` used by the project.
+"""
+
+import subprocess
+import sys
+from typing import Sequence
+
+
+def run_command(cmd: Sequence[str]) -> None:
+    """Run *cmd* in a subprocess and exit on failure."""
+    print("$", " ".join(cmd))
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        print(f"Command failed with exit code {result.returncode}")
+        sys.exit(result.returncode)
+
+
+def main() -> None:
+    packages_to_remove = ["tensorflow", "tensorflow-cpu", "tf-keras"]
+    for pkg in packages_to_remove:
+        run_command([sys.executable, "-m", "pip", "uninstall", "-y", pkg])
+
+    run_command([sys.executable, "-m", "pip", "uninstall", "-y", "transformers"])
+    run_command(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "transformers==4.35.0",
+            "torch==2.2.0",
+            "tokenizers==0.14.1",
+        ]
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,6 +1,8 @@
 fastapi==0.104.1
 uvicorn[standard]==0.24.0
 python-multipart==0.0.6
+
+# PyTorch-only stack — TensorFlow deliberately excluded
 transformers==4.35.0
 torch==2.2.0
 tokenizers==0.14.1


### PR DESCRIPTION
## Summary
- disable TensorFlow in analyzers to avoid float8 import errors
- document PyTorch-only dependencies
- add helper script to strip TensorFlow packages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688b5e950f1c832dac5e815afd78a551