### PR TITLE
fix: enforce pytorch backend for transformers

### DIFF
--- a/api/advanced_analyzer.py
+++ b/api/advanced_analyzer.py
@@ -9,7 +9,18 @@ os.environ.setdefault("TRANSFORMERS_NO_TF", "1")
 os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
 warnings.filterwarnings("ignore", category=UserWarning, module="tensorflow")
 
-from transformers import pipeline
+# Use the same defensive import strategy as in ``analyzer`` to guarantee that
+# TensorFlow is never loaded even if it is present in the environment.
+try:
+    from transformers import pipeline
+except ImportError as e:  # pragma: no cover - defensive fallback
+    if "tensorflow" in str(e).lower():
+        import transformers
+
+        transformers.utils.import_utils.is_tf_available = lambda: False
+        from transformers import pipeline
+    else:  # pragma: no cover
+        raise
 from .analyzer import hybrid_analyzer
 
 _NER_PIPELINE = None

--- a/api/analyzer.py
+++ b/api/analyzer.py
@@ -22,7 +22,25 @@ os.environ.setdefault("TRANSFORMERS_NO_TF", "1")
 os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
 warnings.filterwarnings("ignore", category=UserWarning, module="tensorflow")
 
-from transformers import AutoTokenizer, AutoModelForTokenClassification, pipeline
+# Import transformers while explicitly disabling any TensorFlow backend.  Some
+# versions of ``transformers`` will still try to import ``tensorflow`` if it is
+# present in the environment, even when ``TRANSFORMERS_NO_TF`` is set.  To be
+# completely safe we patch ``is_tf_available`` to always return ``False`` if an
+# ImportError mentioning TensorFlow is raised.
+try:
+    from transformers import AutoTokenizer, AutoModelForTokenClassification, pipeline
+except ImportError as e:  # pragma: no cover - defensive fallback
+    if "tensorflow" in str(e).lower():
+        import transformers
+
+        transformers.utils.import_utils.is_tf_available = lambda: False
+        from transformers import (
+            AutoTokenizer,
+            AutoModelForTokenClassification,
+            pipeline,
+        )
+    else:  # pragma: no cover - bubble up unexpected import errors
+        raise
 
 logger = logging.getLogger(__name__)
 

--- a/api/distilcamembert_validation.py
+++ b/api/distilcamembert_validation.py
@@ -1,0 +1,32 @@
+import os
+
+def test_distilcamembert():
+    """Load DistilCamemBERT NER pipeline using PyTorch only."""
+    os.environ["TRANSFORMERS_NO_TF"] = "1"
+    os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+    os.environ["USE_TF"] = "0"
+    os.environ["USE_TORCH"] = "1"
+
+    try:
+        from transformers import pipeline
+    except ImportError as e:
+        if "tensorflow" in str(e).lower():
+            import transformers
+
+            transformers.utils.import_utils.is_tf_available = lambda: False
+            from transformers import pipeline
+        else:
+            raise
+
+    ner = pipeline(
+        "ner",
+        model="cmarkea/distilcamembert-base-ner",
+        tokenizer="cmarkea/distilcamembert-base-ner",
+        device=-1,
+    )
+    result = ner("Jean Dupont travaille chez OpenAI.")
+    print("✅ DistilCamemBERT fonctionne:", result)
+    return True
+
+if __name__ == "__main__":
+    test_distilcamembert()

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,9 +3,10 @@ uvicorn[standard]==0.24.0
 python-multipart==0.0.6
 
 # PyTorch-only stack — TensorFlow deliberately excluded
-transformers==4.35.0
 torch==2.2.0
-tokenizers==0.14.1
+transformers==4.30.0
+tokenizers==0.13.3
+numpy<2
 python-docx==1.1.0
 PyPDF2==3.0.1
 pdf2image==1.16.3


### PR DESCRIPTION
## Summary
- guard transformer imports so TensorFlow is never loaded
- pin transformers/tokenizers versions for a PyTorch-only setup
- add DistilCamemBERT validation script

## Testing
- `pytest -q`
- `python api/distilcamembert_validation.py` *(fails: Unable to connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688b6147a080832d870f0f761f18354b