### PR TITLE
fix: enforce pytorch backend for transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ cd api
 pip install -r requirements.txt
 
 # Test du modèle DistilCamemBERT
-python -c "from transformers import pipeline; ner = pipeline('ner', model='cmarkea/distilcamembert-base-ner'); print('✅ Modèle DistilCamemBERT opérationnel')"
+python -c "from transformers import pipeline; ner = pipeline('ner', model='cmarkea/distilcamembert-base-ner', tokenizer='cmarkea/distilcamembert-base-ner', use_fast=False); print('✅ Modèle DistilCamemBERT opérationnel')"
 ```
 
 ### Tests de Performance
@@ -317,7 +317,7 @@ VITE_MAX_FILE_SIZE=52428800
 #### ❌ Erreur "Model not found"
 ```bash
 # Solution : Vérifier le cache DistilCamemBERT
-python -c "from transformers import pipeline; pipeline('ner', model='cmarkea/distilcamembert-base-ner')"
+python -c "from transformers import pipeline; pipeline('ner', model='cmarkea/distilcamembert-base-ner', tokenizer='cmarkea/distilcamembert-base-ner', use_fast=False)"
 ```
 
 #### ❌ Timeout Vercel (>30s)

--- a/api/distilcamembert_validation.py
+++ b/api/distilcamembert_validation.py
@@ -1,0 +1,33 @@
+import os
+
+def test_distilcamembert():
+    """Load DistilCamemBERT NER pipeline using PyTorch only."""
+    os.environ["TRANSFORMERS_NO_TF"] = "1"
+    os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+    os.environ["USE_TF"] = "0"
+    os.environ["USE_TORCH"] = "1"
+
+    try:
+        from transformers import pipeline
+    except ImportError as e:
+        if "tensorflow" in str(e).lower():
+            import transformers
+
+            transformers.utils.import_utils.is_tf_available = lambda: False
+            from transformers import pipeline
+        else:
+            raise
+
+    ner = pipeline(
+        "ner",
+        model="cmarkea/distilcamembert-base-ner",
+        tokenizer="cmarkea/distilcamembert-base-ner",
+        device=-1,
+        use_fast=False,
+    )
+    result = ner("Jean Dupont travaille chez OpenAI.")
+    print("✅ DistilCamemBERT fonctionne:", result)
+    return True
+
+if __name__ == "__main__":
+    test_distilcamembert()

--- a/api/fix_dependencies.py
+++ b/api/fix_dependencies.py
@@ -32,9 +32,8 @@ def main() -> None:
             "-m",
             "pip",
             "install",
-            "transformers==4.35.0",
+            "transformers==4.30.0",
             "torch==2.2.0",
-            "tokenizers==0.14.1",
         ]
     )
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,9 +3,9 @@ uvicorn[standard]==0.24.0
 python-multipart==0.0.6
 
 # PyTorch-only stack — TensorFlow deliberately excluded
-transformers==4.35.0
 torch==2.2.0
-tokenizers==0.14.1
+transformers==4.30.0
+numpy<2
 python-docx==1.1.0
 PyPDF2==3.0.1
 pdf2image==1.16.3


### PR DESCRIPTION
## Summary
- guard transformer imports so TensorFlow is never loaded
- pin transformers versions and remove tokenizers dependency
- add DistilCamemBERT validation script

## Testing
- `pytest -q`
- `python api/distilcamembert_validation.py` *(fails: Unable to connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688b6147a080832d870f0f761f18354b