### PR TITLE
Switch to slow tokenizers

### DIFF
--- a/api/advanced_analyzer.py
+++ b/api/advanced_analyzer.py
@@ -12,13 +12,13 @@ warnings.filterwarnings("ignore", category=UserWarning, module="tensorflow")
 # Use the same defensive import strategy as in ``analyzer`` to guarantee that
 # TensorFlow is never loaded even if it is present in the environment.
 try:
-    from transformers import pipeline
+    from transformers import AutoTokenizer, pipeline
 except ImportError as e:  # pragma: no cover - defensive fallback
     if "tensorflow" in str(e).lower():
         import transformers
 
         transformers.utils.import_utils.is_tf_available = lambda: False
-        from transformers import pipeline
+        from transformers import AutoTokenizer, pipeline
     else:  # pragma: no cover
         raise
 from .analyzer import hybrid_analyzer
@@ -31,10 +31,13 @@ def analyze_advanced(text: str) -> Dict:
         entities.append({"text": e.text, "label": e.type, "start": e.start, "end": e.end, "source": "REGEX"})
     global _NER_PIPELINE
     if _NER_PIPELINE is None:
+        tokenizer = AutoTokenizer.from_pretrained(
+            "cmarkea/distilcamembert-base-ner", use_fast=False
+        )
         _NER_PIPELINE = pipeline(
             "ner",
             model="cmarkea/distilcamembert-base-ner",
-            tokenizer="cmarkea/distilcamembert-base-ner",
+            tokenizer=tokenizer,
             aggregation_strategy="simple",
         )
     ner_results = _NER_PIPELINE(text)

--- a/api/analyzer.py
+++ b/api/analyzer.py
@@ -28,7 +28,7 @@ warnings.filterwarnings("ignore", category=UserWarning, module="tensorflow")
 # completely safe we patch ``is_tf_available`` to always return ``False`` if an
 # ImportError mentioning TensorFlow is raised.
 try:
-    from transformers import AutoTokenizer, AutoModelForTokenClassification, pipeline
+    from transformers import AutoTokenizer, pipeline
 except ImportError as e:  # pragma: no cover - defensive fallback
     if "tensorflow" in str(e).lower():
         import transformers
@@ -36,7 +36,6 @@ except ImportError as e:  # pragma: no cover - defensive fallback
         transformers.utils.import_utils.is_tf_available = lambda: False
         from transformers import (
             AutoTokenizer,
-            AutoModelForTokenClassification,
             pipeline,
         )
     else:  # pragma: no cover - bubble up unexpected import errors
@@ -177,13 +176,16 @@ class HybridAnalyzer:
         if self._ner_pipeline is None:
             logger.info("🔄 Chargement du modèle DistilCamemBERT...")
             try:
+                tokenizer = AutoTokenizer.from_pretrained(
+                    self.ner_model_name, use_fast=False
+                )
                 self._ner_pipeline = pipeline(
                     "ner",
                     model=self.ner_model_name,
-                    tokenizer=self.ner_model_name,
+                    tokenizer=tokenizer,
                     aggregation_strategy="simple",
                     device=-1,  # CPU pour compatibilité Vercel
-                    return_all_scores=False  # Économie mémoire
+                    return_all_scores=False,  # Économie mémoire
                 )
                 logger.info("✅ Modèle DistilCamemBERT chargé avec succès")
             except Exception as e:

--- a/api/distilcamembert_validation.py
+++ b/api/distilcamembert_validation.py
@@ -8,20 +8,23 @@ def test_distilcamembert():
     os.environ["USE_TORCH"] = "1"
 
     try:
-        from transformers import pipeline
+        from transformers import AutoTokenizer, pipeline
     except ImportError as e:
         if "tensorflow" in str(e).lower():
             import transformers
 
             transformers.utils.import_utils.is_tf_available = lambda: False
-            from transformers import pipeline
+            from transformers import AutoTokenizer, pipeline
         else:
             raise
 
+    tokenizer = AutoTokenizer.from_pretrained(
+        "cmarkea/distilcamembert-base-ner", use_fast=False
+    )
     ner = pipeline(
         "ner",
         model="cmarkea/distilcamembert-base-ner",
-        tokenizer="cmarkea/distilcamembert-base-ner",
+        tokenizer=tokenizer,
         device=-1,
     )
     result = ner("Jean Dupont travaille chez OpenAI.")

--- a/api/fix_dependencies.py
+++ b/api/fix_dependencies.py
@@ -34,7 +34,6 @@ def main() -> None:
             "install",
             "transformers==4.35.0",
             "torch==2.2.0",
-            "tokenizers==0.14.1",
         ]
     )
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,7 +5,6 @@ python-multipart==0.0.6
 # PyTorch-only stack — TensorFlow deliberately excluded
 torch==2.2.0
 transformers==4.30.0
-tokenizers==0.13.3
 numpy<2
 python-docx==1.1.0
 PyPDF2==3.0.1


### PR DESCRIPTION
## Summary
- avoid requiring Rust `tokenizers` by loading DistilCamemBERT tokenizer with `use_fast=False`
- drop explicit `tokenizers` dependency from requirements and dependency fixer

## Testing
- `python -m py_compile api/analyzer.py api/advanced_analyzer.py api/distilcamembert_validation.py api/fix_dependencies.py`


------
https://chatgpt.com/codex/tasks/task_e_688b770fe3b0832d85ee064b29d461a2