### PR TITLE
Add FastAPI skeleton for anonymizer project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
 # Projet Anonymiseur Juridique
 
-Ce dépôt a été réinitialisé pour démarrer le développement d'une application d'anonymisation de documents juridiques.
+Ce dépôt contient une base minimale pour développer une application d'anonymisation de documents juridiques. L'objectif final est d'offrir une interface permettant d'uploader un document (DOCX ou PDF), d'analyser les entités sensibles puis de télécharger un DOCX anonymisé tout en préservant le format original.
+
+## Structure du projet
+
+```
+backend/
+  main.py             # API FastAPI basique (upload, pages placeholder)
+  requirements.txt    # Dépendances backend
+  templates/          # Pages HTML (index, progression, interface)
+  static/             # Fichiers statiques (CSS)
+```
+
+## Démarrer le serveur de développement
+
+```bash
+pip install -r backend/requirements.txt
+uvicorn backend.main:app --reload
+```
+
+Ouvrir ensuite [http://localhost:8000](http://localhost:8000) pour accéder à la page d'accueil.
 
 ## Fonctionnalités prévues
 - **Mode Regex** : détection rapide de 8 entités (LOC, ADDRESS, EMAIL, PHONE, DATE, IBAN, SIREN, SIRET)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,45 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from fastapi import Request
+import os
+
+app = FastAPI(title="Anonymiseur de documents juridiques")
+
+# Mount static files and templates
+app.mount("/static", StaticFiles(directory="backend/static"), name="static")
+templates = Jinja2Templates(directory="backend/templates")
+
+ALLOWED_EXTENSIONS = {"pdf", "docx"}
+MAX_FILE_SIZE_MB = 25
+
+@app.get("/", response_class=HTMLResponse)
+def read_index(request: Request):
+    """Render the upload page."""
+    return templates.TemplateResponse("index.html", {"request": request})
+
+@app.post("/upload")
+async def upload_file(file: UploadFile = File(...)):
+    """Handle file upload and perform basic validation."""
+    extension = file.filename.split(".")[-1].lower()
+    if extension not in ALLOWED_EXTENSIONS:
+        raise HTTPException(status_code=400, detail="Format non pris en charge")
+
+    contents = await file.read()
+    size_mb = len(contents) / (1024 * 1024)
+    if size_mb > MAX_FILE_SIZE_MB:
+        raise HTTPException(status_code=400, detail="Fichier trop volumineux")
+
+    # TODO: Sauvegarde et traitement du document
+    return {"filename": file.filename, "message": "Upload réussi"}
+
+@app.get("/progress", response_class=HTMLResponse)
+def progress_page(request: Request):
+    """Placeholder progression page."""
+    return templates.TemplateResponse("progress.html", {"request": request})
+
+@app.get("/interface", response_class=HTMLResponse)
+def interface_page(request: Request):
+    """Placeholder unified interface page."""
+    return templates.TemplateResponse("interface.html", {"request": request})

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+python-docx
+pdfplumber

--- a/backend/static/css/styles.css
+++ b/backend/static/css/styles.css
@@ -1,0 +1,1 @@
+body { font-family: Arial, sans-serif; margin: 20px; }

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Anonymiseur de documents juridiques</title>
+    <link rel="stylesheet" href="/static/css/styles.css">
+</head>
+<body>
+    <h1>Anonymiseur de documents juridiques</h1>
+    <div>
+        <form action="/upload" method="post" enctype="multipart/form-data">
+            <label>Choisissez le mode :</label>
+            <div>
+                <input type="radio" id="regex" name="mode" value="regex" checked>
+                <label for="regex">Analyse simple (Regex)</label>
+                <input type="radio" id="ai" name="mode" value="ai">
+                <label for="ai">Analyse IA (NER + Regex)</label>
+            </div>
+            <div>
+                <input type="file" name="file" accept=".pdf,.docx" required />
+            </div>
+            <button type="submit">Envoyer</button>
+        </form>
+        <p>Format de sortie : DOCX identique au document original</p>
+    </div>
+</body>
+</html>

--- a/backend/templates/interface.html
+++ b/backend/templates/interface.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Interface Unifiée</title>
+    <link rel="stylesheet" href="/static/css/styles.css">
+</head>
+<body>
+    <h2>Interface Unifiée</h2>
+    <div style="display:flex;">
+        <div style="flex:7; border:1px solid #ccc; padding:10px;">
+            <p>Visualisateur du document (placeholder)</p>
+        </div>
+        <div style="flex:3; border:1px solid #ccc; padding:10px;">
+            <p>Panneau latéral avec onglets (placeholder)</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/backend/templates/progress.html
+++ b/backend/templates/progress.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Progression</title>
+    <link rel="stylesheet" href="/static/css/styles.css">
+</head>
+<body>
+    <h2>Analyse en cours...</h2>
+    <div id="progress">
+        <!-- Placeholder progress bar -->
+        <div style="width: 50%; background: lightgray;">
+            <div style="width: 25%; height: 20px; background: green;"></div>
+        </div>
+    </div>
+    <p>Préservation du format original en cours...</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add FastAPI backend with upload endpoint and placeholder pages
- document project structure and development instructions

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6899d4ea1b58832dafec9c7ff60799d3