### PR TITLE
Add job status API with progress bar

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, UploadFile, File, Form, HTTPException, Request
+from fastapi import FastAPI, UploadFile, File, Form, HTTPException, Request, BackgroundTasks
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -19,6 +19,9 @@ templates = Jinja2Templates(directory="backend/templates")
 ALLOWED_EXTENSIONS = {"pdf", "docx"}
 MAX_FILE_SIZE_MB = 25
 
+# simple in-memory job store
+jobs: dict[str, dict] = {}
+
 
 def merge_entities(a: list[Entity], b: list[Entity]) -> list[Entity]:
     seen = set()
@@ -35,69 +38,84 @@ def read_index(request: Request):
     """Render the upload page."""
     return templates.TemplateResponse("index.html", {"request": request})
 
+def _process_file(job_id: str, mode: str, confidence: float, contents: bytes, filename: str):
+    """Internal worker updating job status while processing the file."""
+    try:
+        extension = filename.split(".")[-1].lower()
+        if extension not in ALLOWED_EXTENSIONS:
+            jobs[job_id] = {"status": "error", "message": "Format non pris en charge"}
+            return
+
+        size_mb = len(contents) / (1024 * 1024)
+        if size_mb > MAX_FILE_SIZE_MB:
+            jobs[job_id] = {"status": "error", "message": "Fichier trop volumineux"}
+            return
+
+        if mode not in {"regex", "ai"}:
+            jobs[job_id] = {"status": "error", "message": "Mode inconnu"}
+            return
+
+        jobs[job_id]["progress"] = 10
+        if extension == "docx":
+            anonymized_data, regex_entities, positions, text = regex_anonymizer.anonymize_docx(contents)
+            jobs[job_id]["progress"] = 60
+            if mode == "ai":
+                ai_entities = ai_anonymizer.detect(text, confidence)
+                entities = merge_entities(regex_entities, ai_entities)
+            else:
+                entities = regex_entities
+            jobs[job_id]["progress"] = 90
+            output_dir = Path("backend/static/uploads")
+            output_dir.mkdir(parents=True, exist_ok=True)
+            output_filename = f"{uuid4().hex}_{filename}"
+            output_path = output_dir / output_filename
+            with open(output_path, "wb") as f:
+                f.write(anonymized_data)
+            result = {
+                "filename": filename,
+                "entities": [e.__dict__ for e in entities],
+                "positions": positions,
+                "download_url": f"/static/uploads/{output_filename}",
+            }
+        else:
+            anonymized_text, regex_entities, text = regex_anonymizer.anonymize_pdf(contents)
+            jobs[job_id]["progress"] = 60
+            if mode == "ai":
+                ai_entities = ai_anonymizer.detect(text, confidence)
+                entities = merge_entities(regex_entities, ai_entities)
+            else:
+                entities = regex_entities
+            jobs[job_id]["progress"] = 90
+            output_dir = Path("backend/static/uploads")
+            output_dir.mkdir(parents=True, exist_ok=True)
+            output_filename = f"{uuid4().hex}_{Path(filename).stem}.txt"
+            output_path = output_dir / output_filename
+            with open(output_path, "w", encoding="utf-8") as f:
+                f.write(anonymized_text)
+            result = {
+                "filename": filename,
+                "text": anonymized_text,
+                "entities": [e.__dict__ for e in entities],
+                "download_url": f"/static/uploads/{output_filename}",
+            }
+        jobs[job_id].update({"status": "completed", "progress": 100, "result": result})
+    except Exception as exc:
+        jobs[job_id] = {"status": "error", "message": str(exc)}
+
+
 @app.post("/upload")
 async def upload_file(
+    background_tasks: BackgroundTasks,
     mode: str = Form(...),
     confidence: float = Form(0.5),
     file: UploadFile = File(...),
 ):
-    """Handle file upload, anonymize and return detected entities."""
-    extension = file.filename.split(".")[-1].lower()
-    if extension not in ALLOWED_EXTENSIONS:
-        raise HTTPException(status_code=400, detail="Format non pris en charge")
-
+    """Handle file upload asynchronously and return a job identifier."""
     contents = await file.read()
-    size_mb = len(contents) / (1024 * 1024)
-    if size_mb > MAX_FILE_SIZE_MB:
-        raise HTTPException(status_code=400, detail="Fichier trop volumineux")
-
-    if mode not in {"regex", "ai"}:
-        raise HTTPException(status_code=400, detail="Mode inconnu")
-
-    if extension == "docx":
-        anonymized_data, regex_entities, positions, text = regex_anonymizer.anonymize_docx(
-            contents
-        )
-        if mode == "ai":
-            ai_entities = ai_anonymizer.detect(text, confidence)
-            entities = merge_entities(regex_entities, ai_entities)
-        else:
-            entities = regex_entities
-
-        output_dir = Path("backend/static/uploads")
-        output_dir.mkdir(parents=True, exist_ok=True)
-        output_filename = f"{uuid4().hex}_{file.filename}"
-        output_path = output_dir / output_filename
-        with open(output_path, "wb") as f:
-            f.write(anonymized_data)
-
-        return {
-            "filename": file.filename,
-            "entities": [e.__dict__ for e in entities],
-            "positions": positions,
-            "download_url": f"/static/uploads/{output_filename}",
-        }
-    else:
-        anonymized_text, regex_entities, text = regex_anonymizer.anonymize_pdf(contents)
-        if mode == "ai":
-            ai_entities = ai_anonymizer.detect(text, confidence)
-            entities = merge_entities(regex_entities, ai_entities)
-        else:
-            entities = regex_entities
-
-        output_dir = Path("backend/static/uploads")
-        output_dir.mkdir(parents=True, exist_ok=True)
-        output_filename = f"{uuid4().hex}_{Path(file.filename).stem}.txt"
-        output_path = output_dir / output_filename
-        with open(output_path, "w", encoding="utf-8") as f:
-            f.write(anonymized_text)
-
-        return {
-            "filename": file.filename,
-            "text": anonymized_text,
-            "entities": [e.__dict__ for e in entities],
-            "download_url": f"/static/uploads/{output_filename}",
-        }
+    job_id = uuid4().hex
+    jobs[job_id] = {"status": "processing", "progress": 0}
+    background_tasks.add_task(_process_file, job_id, mode, confidence, contents, file.filename)
+    return {"job_id": job_id}
 
 @app.get("/progress", response_class=HTMLResponse)
 def progress_page(request: Request):
@@ -108,3 +126,12 @@ def progress_page(request: Request):
 def interface_page(request: Request):
     """Placeholder unified interface page."""
     return templates.TemplateResponse("interface.html", {"request": request})
+
+
+@app.get("/status/{job_id}")
+def get_status(job_id: str):
+    """Return processing status for a given job id."""
+    job = jobs.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job inconnu")
+    return job

--- a/backend/static/css/styles.css
+++ b/backend/static/css/styles.css
@@ -1,1 +1,4 @@
 body { font-family: Arial, sans-serif; margin: 20px; }
+
+#progress-container { width: 100%; background: lightgray; height: 20px; }
+#progress-bar { width: 0; height: 100%; background: green; transition: width 0.5s; }

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -8,7 +8,7 @@
 <body>
     <h1>Anonymiseur de documents juridiques</h1>
     <div>
-        <form action="/upload" method="post" enctype="multipart/form-data">
+        <form id="upload-form" action="/upload" method="post" enctype="multipart/form-data">
             <label>Choisissez le mode :</label>
             <div>
                 <input type="radio" id="regex" name="mode" value="regex" checked>
@@ -33,6 +33,17 @@
         const output = document.getElementById('confidence-value');
         slider.addEventListener('input', () => {
             output.textContent = parseFloat(slider.value).toFixed(2);
+        });
+
+        const form = document.getElementById('upload-form');
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const formData = new FormData(form);
+            const response = await fetch('/upload', { method: 'POST', body: formData });
+            const data = await response.json();
+            if (data.job_id) {
+                window.location.href = `/progress?job_id=${data.job_id}`;
+            }
         });
     </script>
 </body>

--- a/backend/templates/interface.html
+++ b/backend/templates/interface.html
@@ -15,5 +15,21 @@
             <p>Panneau latéral avec onglets (placeholder)</p>
         </div>
     </div>
+    <div id="result"></div>
+
+    <script>
+        const params = new URLSearchParams(window.location.search);
+        const jobId = params.get('job_id');
+        if (jobId) {
+            fetch(`/status/${jobId}`)
+                .then((r) => r.json())
+                .then((data) => {
+                    if (data.result && data.result.download_url) {
+                        const res = document.getElementById('result');
+                        res.innerHTML = `<a href="${data.result.download_url}">Télécharger le résultat</a>`;
+                    }
+                });
+        }
+    </script>
 </body>
 </html>

--- a/backend/templates/progress.html
+++ b/backend/templates/progress.html
@@ -7,12 +7,27 @@
 </head>
 <body>
     <h2>Analyse en cours...</h2>
-    <div id="progress">
-        <!-- Placeholder progress bar -->
-        <div style="width: 50%; background: lightgray;">
-            <div style="width: 25%; height: 20px; background: green;"></div>
-        </div>
+    <div id="progress-container">
+        <div id="progress-bar"></div>
     </div>
     <p>Préservation du format original en cours...</p>
+
+    <script>
+        const params = new URLSearchParams(window.location.search);
+        const jobId = params.get('job_id');
+        const bar = document.getElementById('progress-bar');
+
+        async function checkStatus() {
+            const res = await fetch(`/status/${jobId}`);
+            const data = await res.json();
+            bar.style.width = `${data.progress}%`;
+            if (data.status === 'completed') {
+                window.location.href = `/interface?job_id=${jobId}`;
+            }
+        }
+
+        checkStatus();
+        setInterval(checkStatus, 1000);
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add in-memory job store and `/status/{job_id}` route for tracking analysis progress
- convert uploads into background jobs and return job id
- implement frontend polling progress bar and auto redirect to interface with download link

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899e42a59c8832dab7bd95e1ddcbe50