### PR TITLE
Add advanced search and modals

### DIFF
--- a/backend/static/css/interface.css
+++ b/backend/static/css/interface.css
@@ -12,3 +12,19 @@
 .entity-table th, .entity-table td { border: 1px solid #ccc; padding: 4px; }
 .group-list { list-style: none; padding-left: 0; }
 .group-list li { border: 1px solid #ccc; padding: 4px; margin-bottom: 4px; cursor: move; }
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.modal-content {
+  background: #fff;
+  padding: 20px;
+  border-radius: 4px;
+}

--- a/backend/templates/interface.html
+++ b/backend/templates/interface.html
@@ -26,7 +26,7 @@
         </div>
         <div v-if="activeTab==='entities'">
           <div class="entity-actions">
-            <button @click="addEntity">Ajouter</button>
+            <button @click="showDetectionModal=true">Ajouter détection</button>
             <button @click="deleteSelected">Supprimer sélection</button>
           </div>
           <table class="entity-table">
@@ -45,8 +45,7 @@
         </div>
         <div v-if="activeTab==='groups'">
           <div class="group-actions">
-            <input v-model="newGroupName" placeholder="Nom du groupe" />
-            <button @click="addGroup">Ajouter</button>
+            <button @click="showGroupModal=true">Créer groupe</button>
           </div>
           <ul class="group-list">
             <li v-for="grp in groupStore.items" :key="grp.id" @dragover.prevent @drop="assignToGroup(grp.id,$event)">
@@ -56,12 +55,34 @@
           </ul>
         </div>
         <div v-if="activeTab==='search'">
+          <select v-model="searchType">
+            <option value="text">Texte</option>
+            <option value="regex">Regex</option>
+            <option value="semantic">Sémantique</option>
+          </select>
           <input v-model="searchTerm" placeholder="Rechercher" />
           <button @click="search">Go</button>
         </div>
         <div v-if="activeTab==='rules'">
           <p>Règles (placeholder)</p>
         </div>
+      </div>
+    </div>
+    <div v-if="showDetectionModal" class="modal">
+      <div class="modal-content">
+        <h3>Ajouter détection</h3>
+        <input v-model="newDetection.type" placeholder="Type" />
+        <input v-model="newDetection.value" placeholder="Valeur" />
+        <button @click="confirmDetection">Ajouter</button>
+        <button @click="showDetectionModal=false">Annuler</button>
+      </div>
+    </div>
+    <div v-if="showGroupModal" class="modal">
+      <div class="modal-content">
+        <h3>Créer groupe</h3>
+        <input v-model="newGroupName" placeholder="Nom du groupe" />
+        <button @click="confirmGroup">Créer</button>
+        <button @click="showGroupModal=false">Annuler</button>
       </div>
     </div>
     <div id="download" v-if="status">


### PR DESCRIPTION
## Summary
- support text, regex and semantic search in interface
- add modals to create detections and groups
- expose semantic search API endpoint

## Testing
- `python -m py_compile backend/main.py`
- `node --check backend/static/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6899f41cd1f4832d9321445e3cce36f5