### PR TITLE
Support job-scoped entities and groups

### DIFF
--- a/backend/static/js/app.js
+++ b/backend/static/js/app.js
@@ -1,17 +1,18 @@
 (function () {
   const { createApp, ref, onMounted, computed } = Vue;
   const { createPinia, defineStore } = Pinia;
+  const jobId = new URLSearchParams(window.location.search).get('job_id');
 
   // ----------------------- Stores -----------------------------------
   const useEntityStore = defineStore('entities', {
     state: () => ({ items: [] }),
     actions: {
       async fetch() {
-        const res = await fetch('/entities');
+        const res = await fetch(`/entities/${jobId}`);
         this.items = await res.json();
       },
       async add(entity) {
-        const res = await fetch('/entities', {
+        const res = await fetch(`/entities/${jobId}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(entity),
@@ -19,14 +20,14 @@
         this.items.push(await res.json());
       },
       async update(entity) {
-        await fetch(`/entities/${entity.id}`, {
+        await fetch(`/entities/${jobId}/${entity.id}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(entity),
         });
       },
       async remove(id) {
-        await fetch(`/entities/${id}`, { method: 'DELETE' });
+        await fetch(`/entities/${jobId}/${id}`, { method: 'DELETE' });
         this.items = this.items.filter((e) => e.id !== id);
       },
       reorder(from, to) {
@@ -39,11 +40,11 @@
     state: () => ({ items: [] }),
     actions: {
       async fetch() {
-        const res = await fetch('/groups');
+        const res = await fetch(`/groups/${jobId}`);
         this.items = await res.json();
       },
       async add(group) {
-        const res = await fetch('/groups', {
+        const res = await fetch(`/groups/${jobId}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(group),
@@ -51,11 +52,11 @@
         this.items.push(await res.json());
       },
       async remove(id) {
-        await fetch(`/groups/${id}`, { method: 'DELETE' });
+        await fetch(`/groups/${jobId}/${id}`, { method: 'DELETE' });
         this.items = this.items.filter((g) => g.id !== id);
       },
       async assign(entityId, groupId) {
-        const res = await fetch(`/groups/${groupId}/entities/${entityId}`, { method: 'POST' });
+        const res = await fetch(`/groups/${jobId}/${groupId}/entities/${entityId}`, { method: 'POST' });
         const updated = await res.json();
         const idx = this.items.findIndex((g) => g.id === updated.id);
         if (idx !== -1) this.items[idx] = updated;
@@ -67,7 +68,6 @@
 
   createApp({
     setup() {
-      const jobId = new URLSearchParams(window.location.search).get('job_id');
       const status = ref(null);
       const view = ref('anonymized');
       const docType = ref('');

--- a/tests/test_entities_groups.py
+++ b/tests/test_entities_groups.py
@@ -1,0 +1,29 @@
+from fastapi.testclient import TestClient
+from backend.main import app
+
+client = TestClient(app)
+
+
+def test_entities_and_groups_scoped_by_job():
+    job1 = "job1"
+    job2 = "job2"
+    # create entities for each job
+    e1 = {"id": "e1", "type": "NAME", "value": "Alice"}
+    e2 = {"id": "e2", "type": "NAME", "value": "Bob"}
+    client.post(f"/entities/{job1}", json=e1)
+    client.post(f"/entities/{job2}", json=e2)
+
+    res1 = client.get(f"/entities/{job1}").json()
+    res2 = client.get(f"/entities/{job2}").json()
+    assert [ent["id"] for ent in res1] == ["e1"]
+    assert [ent["id"] for ent in res2] == ["e2"]
+
+    # create group for job1 and assign entity
+    g1 = {"id": "g1", "name": "G1", "entities": []}
+    client.post(f"/groups/{job1}", json=g1)
+    client.post(f"/groups/{job1}/g1/entities/e1")
+
+    groups_job1 = client.get(f"/groups/{job1}").json()
+    groups_job2 = client.get(f"/groups/{job2}").json()
+    assert groups_job1[0]["entities"] == ["e1"]
+    assert groups_job2 == []


### PR DESCRIPTION
## Summary
- scope in-memory entity and group stores by job id
- require job_id on /entities* and /groups* routes
- send job_id in frontend CRUD requests and add regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899fc7fd484832da0e6c8f961a550c7