### PR TITLE
Use original DOCX and mapping for export

### DIFF
--- a/tests/test_export_docx.py
+++ b/tests/test_export_docx.py
@@ -1,0 +1,36 @@
+from io import BytesIO
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from docx import Document
+
+from backend.anonymizer import RegexAnonymizer, Entity
+
+from tests.test_docx_integrity import create_sample_doc
+
+
+def test_export_docx_replaces_entities():
+    data = create_sample_doc()
+    anonymizer = RegexAnonymizer()
+    _, entities, mapping, _ = anonymizer.anonymize_docx(data)
+
+    email = next(e for e in entities if e.type == "EMAIL")
+    loc = next(e for e in entities if e.type == "LOC")
+
+    modified_entities = [
+        Entity(type=email.type, value="REMPLACED", start=email.start, end=email.end),
+        loc,
+    ]
+
+    modified_bytes, _ = anonymizer.export_docx(
+        data, mapping=mapping, entities=modified_entities
+    )
+    doc = Document(BytesIO(modified_bytes))
+    text = "\n".join(p.text for p in doc.paragraphs)
+
+    assert "REMPLACED" in text
+    assert "[LOC]" in text
+    assert "test@example.com" not in text
+    assert "Contact" not in text


### PR DESCRIPTION
## Summary
- replace DOCX values during export using mapping-aware entity updates
- persist original DOCX and mapping for each job
- adjust export endpoint to use stored originals and entity database

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a0061d35c832da5a0a61e1324b7fc