### PR TITLE
Support DOCX output for PDF anonymization

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,7 +2,10 @@ fastapi
 uvicorn
 python-docx
 pdfplumber
+pdf2docx
 jinja2
 transformers
 pytest
 pillow
+httpx
+python-multipart

--- a/tests/test_pdf_to_docx.py
+++ b/tests/test_pdf_to_docx.py
@@ -1,0 +1,29 @@
+from io import BytesIO
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import fitz  # PyMuPDF
+from docx import Document
+
+from backend.anonymizer import RegexAnonymizer
+
+
+def create_pdf() -> bytes:
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), "Contact: test@example.com")
+    return doc.write()
+
+
+def test_pdf_converted_to_anonymized_docx():
+    data = create_pdf()
+    anonymizer = RegexAnonymizer()
+    docx_bytes, entities, mapping, text, _ = anonymizer.anonymize_pdf(data)
+    docx = Document(BytesIO(docx_bytes))
+    full_text = "\n".join(p.text for p in docx.paragraphs)
+    assert "[EMAIL]" in full_text
+    assert any(e.type == "EMAIL" for e in entities)
+    assert mapping
+    assert "Contact: test@example.com" in text


### PR DESCRIPTION
## Summary
- convert PDFs to DOCX and anonymize using docx pipeline
- adjust upload flow to handle converted DOCX and export only DOCX files
- add regression test for PDF to DOCX anonymization

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ae78fced4832db1eba4f4885f04af