### PR TITLE
feat: add multi-page pdf viewer with navigation

### DIFF
--- a/backend/static/css/interface.css
+++ b/backend/static/css/interface.css
@@ -28,3 +28,13 @@
   padding: 20px;
   border-radius: 4px;
 }
+
+.pdf-page {
+  position: relative;
+}
+
+.pdf-highlight {
+  position: absolute;
+  background: rgba(255, 255, 0, 0.5);
+  pointer-events: none;
+}

--- a/backend/templates/interface.html
+++ b/backend/templates/interface.html
@@ -14,6 +14,9 @@
       <button @click="changeView('anonymized')">Anonymisé</button>
       <button @click="zoomIn">Zoom +</button>
       <button @click="zoomOut">Zoom -</button>
+      <button @click="prevPage">Précédent</button>
+      <button @click="nextPage">Suivant</button>
+      <span>{{ currentPage }} / {{ totalPages }}</span>
     </div>
     <div class="container">
       <div id="viewer" class="viewer"></div>


### PR DESCRIPTION
## Summary
- render PDFs page-by-page with pagination and retain zoom state
- add navigation buttons and overlay entity highlights when coordinates are available
- fallback to reconstructed PDF when coordinates are missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689aeb843e04832db287809ccafdfb4f