### PR TITLE
Expose anonymized document URL in job status

### DIFF
--- a/backend/static/js/app.js
+++ b/backend/static/js/app.js
@@ -231,7 +231,10 @@
             }
           }
         } else if (docType.value === 'docx') {
-          const url = view.value === 'original' ? status.value.original_url : status.value.download_url;
+          const url =
+            view.value === 'original'
+              ? status.value.original_url
+              : status.value.anonymized_url;
           const buffer = await fetch(url).then((r) => r.arrayBuffer());
           const container = document.getElementById('viewer');
           await docx.renderAsync(buffer, container);


### PR DESCRIPTION
## Summary
- store anonymized DOCX/PDF outputs and expose their `anonymized_url`
- include `anonymized_url` in `/status/{job_id}` responses
- use `anonymized_url` when rendering anonymized documents in the UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689af132724c832da093eaa51c642e95