### PR TITLE
Add drag-and-drop file upload with size validation

### DIFF
--- a/backend/static/css/styles.css
+++ b/backend/static/css/styles.css
@@ -2,3 +2,19 @@ body { font-family: Arial, sans-serif; margin: 20px; }
 
 #progress-container { width: 100%; background: lightgray; height: 20px; }
 #progress-bar { width: 0; height: 100%; background: green; transition: width 0.5s; }
+
+#dropzone {
+    border: 2px dashed #ccc;
+    padding: 20px;
+    text-align: center;
+    cursor: pointer;
+    margin-top: 10px;
+}
+
+#dropzone.hover {
+    border-color: #333;
+}
+
+.error {
+    color: red;
+}

--- a/backend/static/js/dropzone.js
+++ b/backend/static/js/dropzone.js
@@ -1,0 +1,75 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const dropzone = document.getElementById('dropzone');
+    const fileInput = document.getElementById('file-input');
+    const form = document.getElementById('upload-form');
+    const errorMessage = document.getElementById('error-message');
+    const slider = document.getElementById('confidence');
+    const output = document.getElementById('confidence-value');
+
+    slider.addEventListener('input', () => {
+        output.textContent = parseFloat(slider.value).toFixed(2);
+    });
+
+    dropzone.addEventListener('click', () => fileInput.click());
+
+    dropzone.addEventListener('dragenter', (e) => {
+        e.preventDefault();
+        dropzone.classList.add('hover');
+    });
+
+    dropzone.addEventListener('dragover', (e) => {
+        e.preventDefault();
+    });
+
+    dropzone.addEventListener('dragleave', (e) => {
+        e.preventDefault();
+        dropzone.classList.remove('hover');
+    });
+
+    dropzone.addEventListener('drop', (e) => {
+        e.preventDefault();
+        dropzone.classList.remove('hover');
+        const file = e.dataTransfer.files[0];
+        if (file) {
+            handleFile(file);
+        }
+    });
+
+    fileInput.addEventListener('change', () => {
+        const file = fileInput.files[0];
+        if (file) {
+            handleFile(file);
+        }
+    });
+
+    function handleFile(file) {
+        if (file.size > 25 * 1024 * 1024) {
+            fileInput.value = '';
+            errorMessage.textContent = 'Le fichier dépasse la taille maximale de 25 Mo.';
+            return;
+        }
+        errorMessage.textContent = '';
+        const dataTransfer = new DataTransfer();
+        dataTransfer.items.add(file);
+        fileInput.files = dataTransfer.files;
+    }
+
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const file = fileInput.files[0];
+        if (!file) {
+            errorMessage.textContent = 'Veuillez sélectionner un fichier.';
+            return;
+        }
+        if (file.size > 25 * 1024 * 1024) {
+            errorMessage.textContent = 'Le fichier dépasse la taille maximale de 25 Mo.';
+            return;
+        }
+        const formData = new FormData(form);
+        const response = await fetch('/upload', { method: 'POST', body: formData });
+        const data = await response.json();
+        if (data.job_id) {
+            window.location.href = `/progress?job_id=${data.job_id}`;
+        }
+    });
+});

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -21,30 +21,15 @@
                 <input type="range" id="confidence" name="confidence" min="0" max="1" step="0.01" value="0.5">
                 <span id="confidence-value">0.50</span>
             </div>
-            <div>
-                <input type="file" name="file" accept=".pdf,.docx" required />
+            <div id="dropzone" class="dropzone">
+                Déposez votre fichier ici ou cliquez pour sélectionner
+                <input type="file" id="file-input" name="file" accept=".pdf,.docx" required hidden />
             </div>
+            <p id="error-message" class="error"></p>
             <button type="submit">Envoyer</button>
         </form>
         <p>Format de sortie : DOCX identique au document original</p>
     </div>
-    <script>
-        const slider = document.getElementById('confidence');
-        const output = document.getElementById('confidence-value');
-        slider.addEventListener('input', () => {
-            output.textContent = parseFloat(slider.value).toFixed(2);
-        });
-
-        const form = document.getElementById('upload-form');
-        form.addEventListener('submit', async (e) => {
-            e.preventDefault();
-            const formData = new FormData(form);
-            const response = await fetch('/upload', { method: 'POST', body: formData });
-            const data = await response.json();
-            if (data.job_id) {
-                window.location.href = `/progress?job_id=${data.job_id}`;
-            }
-        });
-    </script>
+    <script src="/static/js/dropzone.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add drag-and-drop dropzone to index page for file uploads
- validate dropped or selected files on client side (25 MB limit)
- highlight dropzone and display browser-side error messages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689af96b1d94832d8db66807bea1750e