### PR TITLE
feat: display entity metadata

### DIFF
--- a/backend/static/js/app.js
+++ b/backend/static/js/app.js
@@ -9,7 +9,12 @@
     actions: {
       async fetch() {
         const res = await fetch(`/entities/${jobId}`);
-        this.items = await res.json();
+        this.items = (await res.json()).map((e) => ({
+          replacement: '',
+          page: null,
+          confidence: null,
+          ...e,
+        }));
       },
       async add(entity) {
         const res = await fetch(`/entities/${jobId}`, {
@@ -87,7 +92,7 @@
       const showExportModal = ref(false);
       const watermark = ref('');
       const wantAudit = ref(false);
-      const newDetection = ref({ type: '', value: '' });
+      const newDetection = ref({ type: '', value: '', replacement: '', page: null, confidence: null });
       const rules = ref({ regex_rules: [], ner: { confidence: 0.5 }, styles: {} });
       const newRegex = ref({ pattern: '', replacement: '' });
       const newStyle = ref({ type: '', style: '' });
@@ -112,6 +117,9 @@
         eta.value = data.eta;
         entityStore.items = (data.result.entities || []).map((e) => ({
           id: crypto.randomUUID(),
+          replacement: '',
+          page: null,
+          confidence: null,
           ...e,
         }));
         docType.value = data.result.filename.split('.').pop().toLowerCase();
@@ -383,10 +391,13 @@
           id: crypto.randomUUID(),
           type: newDetection.value.type,
           value: newDetection.value.value,
+          replacement: newDetection.value.replacement || '',
+          page: newDetection.value.page ?? currentPage.value,
+          confidence: newDetection.value.confidence,
           start: 0,
           end: 0,
         });
-        newDetection.value = { type: '', value: '' };
+        newDetection.value = { type: '', value: '', replacement: '', page: null, confidence: null };
         showDetectionModal.value = false;
       };
       const deleteGroup = async (id) => {

--- a/backend/templates/interface.html
+++ b/backend/templates/interface.html
@@ -34,7 +34,14 @@
           </div>
           <table class="entity-table">
             <thead>
-              <tr><th></th><th>Type</th><th>Valeur</th></tr>
+              <tr>
+                <th></th>
+                <th>Type</th>
+                <th>Valeur</th>
+                <th>Remplacement</th>
+                <th>Page</th>
+                <th v-if="processingMode==='ai'">Confiance</th>
+              </tr>
             </thead>
             <tbody>
               <tr v-for="(ent,idx) in entityStore.items" :key="ent.id" draggable="true"
@@ -42,6 +49,9 @@
                 <td><input type="checkbox" v-model="selected" :value="ent.id" /></td>
                 <td><input v-model="ent.type" @change="updateEntity(ent)" /></td>
                 <td><input v-model="ent.value" @change="updateEntity(ent)" /></td>
+                <td><input v-model="ent.replacement" @change="updateEntity(ent)" /></td>
+                <td><input v-model.number="ent.page" type="number" @change="updateEntity(ent)" /></td>
+                <td v-if="processingMode==='ai'"><input v-model.number="ent.confidence" type="number" step="0.01" @change="updateEntity(ent)" /></td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
## Summary
- show replacement, page and confidence columns on entity list
- support editing and saving new entity metadata

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689afc237978832db964a293002b41e6