### PR TITLE
Fix interface template Jinja syntax error

### DIFF
--- a/backend/templates/interface.html
+++ b/backend/templates/interface.html
@@ -432,7 +432,7 @@
                                          class="p-3 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer">
                                         <div class="text-sm font-medium text-gray-800 mb-1">{{ result.text }}</div>
                                         <div class="flex items-center justify-between">
-                                            <span class="text-xs text-gray-500">Page {{ result.page || '?' }}</span>
+                                            <span class="text-xs text-gray-500">Page {% raw %}{{ result.page || '?' }}{% endraw %}</span>
                                             <button @click="addSearchResultAsEntity(result)"
                                                     class="px-2 py-1 bg-green-600 text-white rounded text-xs hover:bg-green-700 transition-colors">
                                                 <i class="fas fa-plus mr-1"></i>Ajouter


### PR DESCRIPTION
## Summary
- wrap Vue page indicator expression in Jinja raw block to prevent parsing errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b3ec0c040832db9f1cbb5398f916c