### PR TITLE
Ensure export modal opens only on demand

### DIFF
--- a/backend/static/js/interface-app.js
+++ b/backend/static/js/interface-app.js
@@ -6,7 +6,7 @@
 (function() {
     'use strict';
 
-    const { createApp, ref, computed, onMounted, watch } = Vue;
+    const { createApp, ref, computed, onMounted, watch, nextTick } = Vue;
     const { createPinia, defineStore } = Pinia;
 
     // ============================================================================
@@ -1002,6 +1002,12 @@
 
                 const openExportModal = () => {
                     showExportModal.value = true;
+                    nextTick(() => {
+                        const modal = document.getElementById('export-modal');
+                        if (modal) {
+                            modal.classList.remove('hidden');
+                        }
+                    });
                 };
 
                 // Méthodes de confirmation et fermeture

--- a/backend/templates/interface.html
+++ b/backend/templates/interface.html
@@ -410,7 +410,7 @@
         </div>
 
         <!-- Modal Options d'export -->
-        <div v-if="showExportModal" class="fixed inset-0 bg-black bg-opacity-50 modal-overlay flex items-center justify-center z-50">
+        <div id="export-modal" v-if="showExportModal" class="hidden fixed inset-0 bg-black bg-opacity-50 modal-overlay flex items-center justify-center z-50">
             <div class="bg-white rounded-xl p-6 max-w-lg w-full mx-4 shadow-2xl">
                 <div class="flex items-center mb-6">
                     <div class="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mr-4">


### PR DESCRIPTION
## Summary
- Keep `showExportModal` false until user interaction and cleanly toggle it
- Hide export modal container by default and reveal it when opened

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ca4c70bc4832d933e84cc3b775352