### PR TITLE
Fix modal visibility by relying on Vue conditional rendering

### DIFF
--- a/backend/templates/interface.html
+++ b/backend/templates/interface.html
@@ -337,7 +337,7 @@
         <!-- MODALS - Affiché uniquement quand déclenché par les boutons -->
         
         <!-- Modal Ajout détection manuelle -->
-        <div v-if="showDetectionModal" class="hidden fixed inset-0 bg-black bg-opacity-50 modal-overlay flex items-center justify-center z-50">
+        <div v-if="showDetectionModal" class="fixed inset-0 bg-black bg-opacity-50 modal-overlay flex items-center justify-center z-50">
             <div class="bg-white rounded-xl p-6 max-w-md w-full mx-4 shadow-2xl">
                 <div class="flex items-center mb-6">
                     <div class="w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center mr-4">
@@ -379,7 +379,7 @@
         </div>
 
         <!-- Modal Création de groupe -->
-        <div v-if="showGroupModal" class="hidden fixed inset-0 bg-black bg-opacity-50 modal-overlay flex items-center justify-center z-50">
+        <div v-if="showGroupModal" class="fixed inset-0 bg-black bg-opacity-50 modal-overlay flex items-center justify-center z-50">
             <div class="bg-white rounded-xl p-6 max-w-md w-full mx-4 shadow-2xl">
                 <div class="flex items-center mb-6">
                     <div class="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center mr-4">
@@ -410,7 +410,7 @@
         </div>
 
         <!-- Modal Options d'export -->
-        <div id="export-modal" v-if="showExportModal" class="hidden fixed inset-0 bg-black bg-opacity-50 modal-overlay flex items-center justify-center z-50">
+        <div id="export-modal" v-if="showExportModal" class="fixed inset-0 bg-black bg-opacity-50 modal-overlay flex items-center justify-center z-50">
             <div class="bg-white rounded-xl p-6 max-w-lg w-full mx-4 shadow-2xl">
                 <div class="flex items-center mb-6">
                     <div class="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mr-4">


### PR DESCRIPTION
## Summary
- Remove Tailwind `hidden` class from detection, group, and export modals
- Let Vue's `v-if` handle modal visibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dafd2d520832db426e95987264ad4