### PR TITLE
Use default Vue delimiters

### DIFF
--- a/backend/static/js/interface-app.js
+++ b/backend/static/js/interface-app.js
@@ -1421,9 +1421,6 @@
             return;
         }
 
-        // Configuration Vue pour utiliser [[ ]] au lieu de {{ }}
-        app.config.compilerOptions.delimiters = ['[[', ']]'];
-
         app.use(pinia);
         app.mount('#app');
 

--- a/backend/templates/interface.html
+++ b/backend/templates/interface.html
@@ -58,7 +58,7 @@
                             <button @click="zoomOut" :disabled="!appStore.canZoomOut" class="p-2 text-gray-600 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg hover:bg-gray-100">
                                 <i class="fas fa-search-minus"></i>
                             </button>
-                            <span class="text-sm text-gray-600 min-w-16 text-center">[[zoomPercentage]]</span>
+                            <span class="text-sm text-gray-600 min-w-16 text-center">{{zoomPercentage}}</span>
                             <button @click="zoomIn" :disabled="!appStore.canZoomIn" class="p-2 text-gray-600 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg hover:bg-gray-100">
                                 <i class="fas fa-search-plus"></i>
                             </button>
@@ -69,7 +69,7 @@
                             <button @click="prevPage" :disabled="currentPage <= 1" class="p-2 text-gray-600 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg hover:bg-gray-100">
                                 <i class="fas fa-chevron-left"></i>
                             </button>
-                            <span class="text-sm text-gray-600">[[pageInfo]]</span>
+                            <span class="text-sm text-gray-600">{{pageInfo}}</span>
                             <button @click="nextPage" :disabled="currentPage >= totalPages" class="p-2 text-gray-600 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg hover:bg-gray-100">
                                 <i class="fas fa-chevron-right"></i>
                             </button>
@@ -80,7 +80,7 @@
                     <div class="flex items-center space-x-6 text-sm text-gray-600">
                         <div class="flex items-center">
                             <i class="fas fa-tags mr-2 text-blue-600"></i>
-                            <span>[[entitiesCount]] entités</span>
+                            <span>{{entitiesCount}} entités</span>
                         </div>
                         <div v-if="processingMode === 'ai'" class="flex items-center">
                             <i class="fas fa-brain mr-2 text-purple-600"></i>
@@ -113,7 +113,7 @@
                     <div class="flex">
                         <button v-for="tab in tabs" :key="tab.id" @click="activeTab = tab.id" :class="tabButtonClass(tab.id)">
                             <i :class="tab.icon + ' mr-2'"></i>
-                            [[tab.label]]
+                            {{tab.label}}
                         </button>
                     </div>
                 </div>
@@ -142,7 +142,7 @@
                             <div v-if="selectedEntities.length > 0" class="flex space-x-2">
                                 <select v-model="bulkGroupId" class="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm">
                                     <option value="">--Assigner au groupe--</option>
-                                    <option v-for="group in groups" :key="group.id" :value="group.id">[[group.name]]</option>
+                                    <option v-for="group in groups" :key="group.id" :value="group.id">{{group.name}}</option>
                                 </select>
                                 <button @click="assignSelectedToGroup" :disabled="!bulkGroupId" class="px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm">
                                     <i class="fas fa-check"></i>
@@ -154,7 +154,7 @@
                         <div class="space-y-2">
                             <div class="flex items-center mb-3">
                                 <input type="checkbox" @change="toggleAllEntities" :checked="allEntitiesSelected" class="mr-2 rounded">
-                                <span class="text-sm text-gray-600">[[selectionInfo]]</span>
+                                <span class="text-sm text-gray-600">{{selectionInfo}}</span>
                             </div>
                             
                             <!-- Entités individuelles -->
@@ -169,8 +169,8 @@
                                     <input type="checkbox" :checked="isEntitySelected(entity.id)" @click.stop @change="toggleEntitySelection(entity.id)" class="mt-1 rounded">
                                     <div class="flex-1 min-w-0">
                                         <div class="flex items-center justify-between mb-2">
-                                            <span :class="entityTypeClass(entity.type)">[[entity.type]]</span>
-                                            <span v-if="entity.page" class="text-xs text-gray-500">Page [[entity.page]]</span>
+                                            <span :class="entityTypeClass(entity.type)">{{entity.type}}</span>
+                                            <span v-if="entity.page" class="text-xs text-gray-500">Page {{entity.page}}</span>
                                         </div>
                                         
                                         <div class="space-y-2">
@@ -185,7 +185,7 @@
                                             
                                             <div v-if="showConfidence(entity)" class="flex items-center justify-between">
                                                 <span class="text-xs text-gray-600">Confiance</span>
-                                                <span class="text-xs font-medium" :class="confidenceClass(entity.confidence)">[[confidenceText(entity.confidence)]]</span>
+                                                <span class="text-xs font-medium" :class="confidenceClass(entity.confidence)">{{confidenceText(entity.confidence)}}</span>
                                             </div>
                                         </div>
                                     </div>
@@ -215,9 +215,9 @@
                         <div class="space-y-3">
                             <div v-for="group in groups" :key="group.id" class="group-item p-4 border border-gray-200 rounded-lg" @dragover.prevent @drop="onDropToGroup(group.id, $event)">
                                 <div class="flex items-center justify-between mb-3">
-                                    <h4 class="font-medium text-gray-800">[[group.name]]</h4>
+                                    <h4 class="font-medium text-gray-800">{{group.name}}</h4>
                                     <div class="flex items-center space-x-2">
-                                        <span class="px-2 py-1 bg-gray-100 text-gray-600 text-xs rounded-full">[[groupEntityCount(group)]]</span>
+                                        <span class="px-2 py-1 bg-gray-100 text-gray-600 text-xs rounded-full">{{groupEntityCount(group)}}</span>
                                         <button @click="deleteGroup(group.id)" class="text-red-500 hover:text-red-700 text-sm">
                                             <i class="fas fa-trash"></i>
                                         </button>
@@ -229,8 +229,8 @@
                                 <div v-if="groupHasEntities(group)" class="space-y-1">
                                     <div v-for="entityId in group.entities" :key="entityId" class="text-xs p-2 bg-gray-50 rounded border">
                                         <template v-if="getEntityById(entityId)">
-                                            [[getEntityById(entityId).value]]
-                                            <span class="text-gray-500 ml-2">([[getEntityById(entityId).type]])</span>
+                                            {{getEntityById(entityId).value}}
+                                            <span class="text-gray-500 ml-2">({{getEntityById(entityId).type}})</span>
                                         </template>
                                         <template v-else>
                                             <span class="text-red-500">Entité introuvable</span>
@@ -270,12 +270,12 @@
                             </div>
                             
                             <div v-if="searchResults.length > 0">
-                                <h4 class="text-sm font-medium text-gray-700 mb-2">Résultats ([[searchResults.length]])</h4>
+                                <h4 class="text-sm font-medium text-gray-700 mb-2">Résultats ({{searchResults.length}})</h4>
                                 <div class="space-y-2 max-h-64 overflow-y-auto">
                                     <div v-for="(result, index) in searchResults" :key="index" class="p-3 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer">
-                                        <div class="text-sm font-medium text-gray-800 mb-1">[[result.text]]</div>
+                                        <div class="text-sm font-medium text-gray-800 mb-1">{{result.text}}</div>
                                         <div class="flex items-center justify-between">
-                                            <span class="text-xs text-gray-500">[[pageLabel(result.page)]]</span>
+                                            <span class="text-xs text-gray-500">{{pageLabel(result.page)}}</span>
                                             <button @click="addSearchResultAsEntity(result)" class="px-2 py-1 bg-green-600 text-white rounded text-xs hover:bg-green-700 transition-colors">
                                                 <i class="fas fa-plus mr-1"></i>Ajouter
                                             </button>
@@ -305,15 +305,15 @@
                 <div class="flex items-center space-x-6 text-sm text-gray-600">
                     <div class="flex items-center">
                         <i class="fas fa-tags mr-2 text-blue-600"></i>
-                        <span>[[entitiesCount]] entités totales</span>
+                        <span>{{entitiesCount}} entités totales</span>
                     </div>
                     <div v-if="selectedEntities.length > 0" class="flex items-center">
                         <i class="fas fa-check-square mr-2 text-green-600"></i>
-                        <span>[[selectedEntities.length]] sélectionnées</span>
+                        <span>{{selectedEntities.length}} sélectionnées</span>
                     </div>
                     <div v-if="groups.length > 0" class="flex items-center">
                         <i class="fas fa-layer-group mr-2 text-purple-600"></i>
-                        <span>[[groups.length]] groupes</span>
+                        <span>{{groups.length}} groupes</span>
                     </div>
                 </div>
                 
@@ -354,7 +354,7 @@
                         <label class="block text-sm font-medium text-gray-700 mb-1">Type d'entité</label>
                         <select v-model="newDetection.type" class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent">
                             <option value="">Sélectionnez un type</option>
-                            <option v-for="entityType in entityTypes" :key="entityType.value" :value="entityType.value">[[entityType.label]]</option>
+                            <option v-for="entityType in entityTypes" :key="entityType.value" :value="entityType.value">{{entityType.label}}</option>
                         </select>
                     </div>
                     <div>
@@ -461,12 +461,12 @@
                     <div class="bg-gray-50 rounded-lg p-4">
                         <h4 class="text-sm font-medium text-gray-700 mb-2">
                             <i class="fas fa-eye mr-2"></i>
-                            Aperçu : [[entitiesCount]] entités seront anonymisées
+                            Aperçu : {{entitiesCount}} entités seront anonymisées
                         </h4>
                         <div class="flex flex-wrap gap-2">
                             <span v-for="(count, type) in entityTypeCounts" :key="type" 
                                   class="px-2 py-1 bg-white border rounded-full text-xs">
-                                [[type]]: [[count]]
+                                {{type}}: {{count}}
                             </span>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- remove custom Vue `[[ ]]` delimiter configuration
- convert templates back to Vue's `{{ }}` syntax
- verify bindings update with default delimiters

## Testing
- `node - <<'NODE' ... NODE`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dd158005c832dbdca2fb6aa6bbe5e