### PR TITLE
refactor: add queued API client with retry and state enums

### DIFF
--- a/backend/static/js/main.js
+++ b/backend/static/js/main.js
@@ -45,9 +45,10 @@ const groupStore = useGroupStore();
 const jobId = new URLSearchParams(window.location.search).get('job_id');
 if (jobId) {
     appStore.setJobId(jobId);
-    // load initial data
-    entityStore.fetch(jobId);
-    groupStore.fetch(jobId);
+    appStore.fetchStatus = 'loading';
+    Promise.all([entityStore.fetch(jobId), groupStore.fetch(jobId)])
+        .then(() => { appStore.fetchStatus = 'loaded'; })
+        .catch(() => { appStore.fetchStatus = 'error'; });
 }
 
 app.mount('#app');

--- a/backend/static/js/services/apiClient.js
+++ b/backend/static/js/services/apiClient.js
@@ -1,0 +1,58 @@
+export class ApiClient {
+    constructor() {
+        this.queue = [];
+        this.processing = false;
+    }
+
+    request(url, options = {}, rollback) {
+        return new Promise((resolve, reject) => {
+            this.queue.push({ url, options, rollback, resolve, reject, attempts: 0 });
+            this._process();
+        });
+    }
+
+    async _process() {
+        if (this.processing || this.queue.length === 0) return;
+        this.processing = true;
+        const item = this.queue.shift();
+        try {
+            const data = await this._fetchWithRetry(item);
+            item.resolve(data);
+        } catch (error) {
+            if (item.rollback) {
+                try { item.rollback(); } catch (_) { /* noop */ }
+            }
+            if (window.toastService) {
+                window.toastService.error(error.message || 'Erreur réseau');
+            }
+            item.reject(error);
+        } finally {
+            this.processing = false;
+            this._process();
+        }
+    }
+
+    async _fetchWithRetry(item) {
+        const maxRetries = 3;
+        while (item.attempts < maxRetries) {
+            try {
+                const response = await fetch(item.url, item.options);
+                if (!response.ok) {
+                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+                }
+                const contentType = response.headers.get('content-type') || '';
+                if (contentType.includes('application/json')) {
+                    return await response.json();
+                }
+                return await response.text();
+            } catch (error) {
+                item.attempts++;
+                if (item.attempts >= maxRetries) {
+                    throw error;
+                }
+            }
+        }
+    }
+}
+
+export const apiClient = new ApiClient();

--- a/backend/static/js/stores/appStore.js
+++ b/backend/static/js/stores/appStore.js
@@ -17,7 +17,7 @@ export const useAppStore = defineStore('app', {
         currentPage: 1,
         totalPages: 1,
         docType: '',
-        loading: false,
+        fetchStatus: 'idle',
         searchTerm: '',
         searchResults: [],
         searchType: 'text'

--- a/backend/static/js/stores/groupStore.js
+++ b/backend/static/js/stores/groupStore.js
@@ -1,11 +1,12 @@
 import { defineStore } from 'pinia';
 import { utils } from '../utils.js';
+import { apiClient } from '../services/apiClient.js';
 
 // Store managing entity groups
 export const useGroupStore = defineStore('groups', {
     state: () => ({
         items: [],
-        loading: false,
+        status: 'idle',
         error: null
     }),
 
@@ -15,100 +16,80 @@ export const useGroupStore = defineStore('groups', {
 
     actions: {
         async fetch(jobId) {
-            this.loading = true;
+            this.status = 'loading';
             this.error = null;
             try {
-                const response = await fetch(`/groups/${jobId}`);
-                if (!response.ok) {
-                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-                }
-                this.items = await response.json();
+                this.items = await apiClient.request(`/groups/${jobId}`);
+                this.status = 'loaded';
             } catch (error) {
                 this.error = error.message;
-                if (window.toastService) {
-                    window.toastService.error('Erreur lors du chargement des groupes');
-                }
-            } finally {
-                this.loading = false;
+                this.status = 'error';
             }
         },
 
         async add(jobId, group) {
+            const temp = { id: group.id || utils.generateId(), entities: [], ...group };
+            this.items.push(temp);
             try {
-                const response = await fetch(`/groups/${jobId}`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        id: group.id || utils.generateId(),
-                        entities: [],
-                        ...group
-                    })
-                });
-
-                if (!response.ok) {
-                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-                }
-
-                const savedGroup = await response.json();
-                this.items.push(savedGroup);
+                const savedGroup = await apiClient.request(
+                    `/groups/${jobId}`,
+                    {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(temp)
+                    },
+                    () => {
+                        this.items = this.items.filter(item => item.id !== temp.id);
+                    }
+                );
+                Object.assign(temp, savedGroup);
                 if (window.toastService) {
                     window.toastService.success('Groupe créé avec succès');
                 }
                 return savedGroup;
             } catch (error) {
-                if (window.toastService) {
-                    window.toastService.error('Erreur lors de la création du groupe');
-                }
                 throw error;
             }
         },
 
         async remove(jobId, groupId) {
+            const index = this.items.findIndex(item => item.id === groupId);
+            if (index === -1) return;
+            const removed = this.items.splice(index, 1)[0];
             try {
-                const response = await fetch(`/groups/${jobId}/${groupId}`, {
-                    method: 'DELETE'
-                });
-
-                if (!response.ok) {
-                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-                }
-
-                this.items = this.items.filter(item => item.id !== groupId);
+                await apiClient.request(
+                    `/groups/${jobId}/${groupId}`,
+                    { method: 'DELETE' },
+                    () => {
+                        this.items.splice(index, 0, removed);
+                    }
+                );
                 if (window.toastService) {
                     window.toastService.success('Groupe supprimé');
                 }
             } catch (error) {
-                if (window.toastService) {
-                    window.toastService.error('Erreur lors de la suppression du groupe');
-                }
                 throw error;
             }
         },
 
         async assignEntity(jobId, entityId, groupId) {
+            const index = this.items.findIndex(item => item.id === groupId);
+            if (index === -1) return;
+            const previous = { ...this.items[index] };
             try {
-                const response = await fetch(`/groups/${jobId}/${groupId}/entities/${entityId}`, {
-                    method: 'POST'
-                });
-
-                if (!response.ok) {
-                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-                }
-
-                const updatedGroup = await response.json();
-                const index = this.items.findIndex(item => item.id === groupId);
-                if (index !== -1) {
-                    this.items[index] = updatedGroup;
-                }
-
+                const updatedGroup = await apiClient.request(
+                    `/groups/${jobId}/${groupId}/entities/${entityId}`,
+                    { method: 'POST' },
+                    () => {
+                        this.items[index] = previous;
+                    }
+                );
+                this.items[index] = updatedGroup;
                 if (window.toastService) {
                     window.toastService.success('Entité assignée au groupe');
                 }
                 return updatedGroup;
             } catch (error) {
-                if (window.toastService) {
-                    window.toastService.error("Erreur lors de l'assignation");
-                }
                 throw error;
             }
         }


### PR DESCRIPTION
## Summary
- replace boolean loading flags with explicit status enums
- queue API requests with retry/rollback handling
- centralize error reporting through shared API client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689ddb6925ec832da3d42fec829ac412